### PR TITLE
Test .gitignore Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/coverage/
+coverage/
 


### PR DESCRIPTION
Cleared memory of coverage from Git so .gitignore is able to properly ignore futbol/coverage/ file
1. git rm -r --cached coverage/