### PR TITLE
Module data_parsable

### DIFF
--- a/lib/data_parsable.rb
+++ b/lib/data_parsable.rb
@@ -1,0 +1,18 @@
+require 'csv'
+
+module DataParsable
+
+  attr_reader :games, :teams, :game_teams
+
+  def initialize(files)
+    @games = parse_data(files[:games], Game)
+    @teams = parse_data(files[:teams], Team)
+    @game_teams = parse_data(files[:game_teams], GameTeam)
+  end
+
+  def parse_data(files, object)
+    (CSV.foreach(files, headers: true, header_converters: :symbol)).map do |row|
+      object.new(row)
+    end
+  end
+end

--- a/lib/game_statable.rb
+++ b/lib/game_statable.rb
@@ -42,15 +42,6 @@ module GameStatable
     @games.each_with_object(Hash.new(0)) { |game, game_count| game_count[game.season] += 1 }
   end
   
-  def count_of_teams
-    @teams.count
-  end
-
-  def count_of_games_by_season
-    @games.each_with_object(Hash.new(0)) { |game, game_count| game_count[game.season] += 1 }
-  end
- 
-
   def total_goals_by_season
     total_goals_by_season = @games.each_with_object(Hash.new(0.0)) { |game, hash| hash[game.season] += game.away_goals + game.home_goals}
   end 

--- a/lib/league_statable.rb
+++ b/lib/league_statable.rb
@@ -1,5 +1,9 @@
 module LeagueStatable
   
+  def count_of_teams
+    @teams.count
+  end
+
   def team_list
     @teams.each_with_object(Hash.new) { |team, team_list| team_list[team.team_id] = team.team_name}
   end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,30 +1,17 @@
-require 'csv'
+# require 'csv'
 require_relative 'team'
 require_relative 'game'
 require_relative "game_team"
 require_relative 'game_statable'
 require_relative 'league_statable'
 require_relative 'season_statable'
+require_relative 'data_parsable'
 
 class StatTracker
+include DataParsable
 include GameStatable
 include LeagueStatable
 include SeasonStatable
-
-  attr_reader :games, :teams, :game_teams
-
-  def initialize(files)
-    @games = (CSV.foreach files[:games], headers: true, header_converters: :symbol).map do |row|
-      Game.new(row)
-    end
-    @teams = (CSV.foreach files[:teams], headers: true, header_converters: :symbol).map do |row|
-      Team.new(row)
-    end
-    @game_teams = (CSV.foreach files[:game_teams], headers: true, header_converters: :symbol).map do |row|
-      GameTeam.new(row)
-    end
-  end
-
 
   def self.from_csv(files)
     StatTracker.new(files)


### PR DESCRIPTION
Classes developed or iterated: 
Took everything out of StatTracker class besides the self.from_csv method

Modules developed or iterated: 
1. data_parsable

Refactor implemented: 

Not so much a refactor but I took out a duplicate method in the game_statable module so that we could get to 100% coverage! it was a duplicate of count_of_games_by_season. Must have happened when dealing with a merge conflict. 

Potential Refactor: 

I'd like to find a way to get the selv.from_csv method into the data_parsable module so that we have nothing but modules inside of our StatTracker class. I tried a few things but wasn't able to make it work. Tried:

1. just naming method from_csv without the self implication, but that doesn't make sense because it's a class method.
2. tried putting self in the method rather than instantiating a new StatTracker object

unsure why neither of these worked, but I think it's something to do with scope? We can chat about it in person. 

Other considerations: 

1. Did some research on having initialize inside of a module and it seems legit. For some reason it felt weird to have it there, but it's technically a method like any other. You just can't initialize a module itself. That's what my research indicated at at least. 
